### PR TITLE
Adjust circle radius in map view for better visibility

### DIFF
--- a/src/contexts/map/TravlyMapView.tsx
+++ b/src/contexts/map/TravlyMapView.tsx
@@ -80,7 +80,7 @@ export const TrvlyMapView: React.FC = () => {
               filter={['has', 'point_count']}
               style={{
                 circleColor: 'red',
-                circleRadius: 30,
+                circleRadius: 20,
                 circleStrokeWidth: 1,
                 circleOpacity: 0.6,
                 circleStrokeColor: 'white',


### PR DESCRIPTION
This pull request includes a small change to the `TravlyMapView` component. The change modifies the `circleRadius` property in the style object to adjust the appearance of map points.

* [`src/contexts/map/TravlyMapView.tsx`](diffhunk://#diff-68154484e1b7aaccaca9dd20b458d6cf3415bb2137613042a3a7cea618d368c9L83-R83): Changed `circleRadius` from 30 to 20 to reduce the size of the circles on the map.